### PR TITLE
Constrain opam deps to < 2.5.0

### DIFF
--- a/packman/dune-project
+++ b/packman/dune-project
@@ -18,9 +18,12 @@
    (>= "3.4"))
   (ocaml
    (>= "4.14"))
-  opam-format
-  opam-state
-  opam-solver
+  (opam-format
+   (< "2.5.0"))
+  (opam-state
+   (< "2.5.0"))
+  (opam-solver
+   (< "2.5.0"))
   containers
   cmdliner
   opam-0install


### PR DESCRIPTION
Fixes issue calling OpamStd.String.for_all which appear to have been removed.